### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of the issue.
+
+**Steps to reproduce**
+Step-by-step list of actions to reproduce the issue.
+
+**Workarounds**
+Are there any workarounds for this behavior?
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**XMP Metadata**
+Attach raw XMP metadata (if applicable).
+
+**Environment**
+* OS type and version:
+* Extension version 
+* Any other relevant info:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,5 +27,5 @@ Attach raw XMP metadata (if applicable).
 
 **Environment**
 * OS type and version:
-* Extension version 
+* Extension version:
 * Any other relevant info:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,6 +25,9 @@ If applicable, add screenshots to help explain your problem.
 **XMP Metadata**
 Attach raw XMP metadata (if applicable).
 
+**Metadata View JSON**
+Export and attach your Metadata View JSON (if applicable).
+
 **Environment**
 * OS type and version:
 * Extension version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Link to any relevant bugs (e.g. "Relates to bug #xxx")
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,10 @@
+---
+name: General question
+about: Issues that are neither bugs nor feature requests
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
Create issue templates for the following issue types:
* Bug
* Feature request
* General question

Not doing a PR template because it doesn't make sense for this repo since it doesn't host any code.